### PR TITLE
chore(defaults): Change defaults for tst.config.json (sameLocation)

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -11,7 +11,7 @@ const schema = z.object({
     .enum(['openai', 'anthropic', 'vertex', 'azure-openai', 'bedrock'])
     .default('openai'),
   model: z.string().default('gpt-4o-mini'),
-  outFormat: z.enum(['sameLocation', 'testDir']).default('testDir'),
+  outFormat: z.enum(['sameLocation', 'testDir']).default('sameLocation'),
   outBaseSrc: z.string().optional(),
   outBaseTest: z.string().optional(),
   astLibrary: z.enum(['ts-morph', 'babel']).default('ts-morph'),


### PR DESCRIPTION
When there is no 'tst.config.json' file, the more sane default is 'sameLocation'. This is no src/dest folder work needed when 'sameLocation' is set. If 'testDir' is set, then, care can go into the the src and test folders.