### PR TITLE
chore(clean): Correct readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,22 +282,24 @@ Determine if this is:
 
 - Ensure main is clean (see step 1).
 
+**NOTE**: The following instructions need to have single quotes (not double quotes) as they can include an exclamation mark (used by the "npm version" command). Without the single quotes, the exclamation mark can be interpreted as a history command by the shell.
+
 #### If Patch
 
 ```
-npm version patch -m "chore(release): %s"
+npm version patch -m 'chore(release): %s'
 ```
 
 #### If Minor
 
 ```
-npm version minor -m "feat!: %s"
+npm version minor -m 'feat!: %s'
 ```
 
 #### If Major
 
 ```
-npm version major -m "feat!: %s"
+npm version major -m 'feat!: %s'
 ```
 
 ### 4) Publish to NPM


### PR DESCRIPTION
The npm version patch instructions contain an exclamation mark. When used within double quotes, that can be interpreted by the shell (as a history command).

The exclamation mark is actually used by 'npm version'. These comments should be passed as single quotes.